### PR TITLE
依存パッケージのセキュリティ脆弱性に追加対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,12 +199,13 @@
     "katex": "^0.16.21",
     "flatted": "^3.4.2",
     "serialize-javascript": "^7.0.5",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.2.0",
     "glob": "^10.5.0",
     "minimatch": "^9.0.7",
     "form-data": "^4.0.6",
     "markdown-it": "^14.2.0",
     "fast-uri": "^3.1.2",
-    "picomatch": "^2.3.2"
+    "picomatch": "^2.3.2",
+    "brace-expansion": "^2.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1067,12 +1067,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2"
+"brace-expansion@npm:^2.0.3":
+  version: 2.1.1
+  resolution: "brace-expansion@npm:2.1.1"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
+  checksum: 10c0/63b5ddce608b70b50a76817c0526faf8ea67a9180073d88bb402f6bbc22a22da6b1dfac4f65efc53e5faa80222fb7d44bbf2fc638c3f55365975573f671d0ccb
   languageName: node
   linkType: hard
 
@@ -2439,14 +2439,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+"js-yaml@npm:^4.2.0":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 概要

残っていた Dependabot アラート 2 件に `resolutions` で対応しました。

| パッケージ | 変更 | 深刻度 | 内容 |
|---|---|---|---|
| js-yaml | 4.1.1 → 4.3.0 | medium | - |
| brace-expansion | 2.0.2 → 2.1.1 | medium | ReDoS |

## 確認

- `yarn run compile` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)